### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_wise-ref.yml
+++ b/.github/workflows/main_wise-ref.yml
@@ -38,6 +38,9 @@ jobs:
   deploy:
     runs-on: windows-latest
     needs: build
+    permissions:
+      contents: read
+      deployments: write
     environment:
       name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}


### PR DESCRIPTION
Potential fix for [https://github.com/MrGMitchell/FootballQuestions.Ui/security/code-scanning/1](https://github.com/MrGMitchell/FootballQuestions.Ui/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `deploy` job. This block should specify the minimal permissions required for the job to function correctly. Based on the workflow, the `deploy` job interacts with Azure Web Apps and downloads artifacts, so it likely requires `contents: read` and possibly other permissions related to deployments. 

The fix involves:
1. Adding a `permissions` block to the `deploy` job.
2. Assigning the least privileges necessary for the job to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
